### PR TITLE
feat: add header image support for markdown posts

### DIFF
--- a/src/content/posts/step-up-to-the-plate.md
+++ b/src/content/posts/step-up-to-the-plate.md
@@ -7,9 +7,8 @@ featured: true
 type: "markdown"
 tags: ["mindset", "learning", "growth"]
 author: "Craig Sturgis"
+headerImage: "/images/posts/step-up-to-the-plate.jpg"
 ---
-
-![Young baseball player ready to bat](/images/posts/step-up-to-the-plate.jpg)
 
 Most of us lose our patience for being a complete beginner.
 

--- a/src/index.css
+++ b/src/index.css
@@ -234,3 +234,11 @@
   padding: 0.5rem 1rem;
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
+
+.markdown-content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.5rem;
+  margin: 1.5rem 0;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -12,6 +12,7 @@ export interface PostMetadata {
   author: string;
   slug: string;
   hidden?: boolean;
+  headerImage?: string;
 }
 
 export interface Post {

--- a/src/pages/ResourcePost.tsx
+++ b/src/pages/ResourcePost.tsx
@@ -158,6 +158,20 @@ export default function ResourcePost() {
             </Link>
           </div>
 
+          {/* Header Image */}
+          {post.metadata.headerImage && (
+            <Card className="bg-white/5 backdrop-blur-sm border-white/10 mb-8 overflow-hidden">
+              <div className="relative w-full" style={{ maxHeight: '400px' }}>
+                <img
+                  src={post.metadata.headerImage}
+                  alt={post.metadata.title}
+                  className="w-full h-auto object-cover"
+                  style={{ maxHeight: '400px' }}
+                />
+              </div>
+            </Card>
+          )}
+
           {/* Article Header */}
           <Card className="bg-white/5 backdrop-blur-sm border-white/10 mb-8">
             <CardContent className="p-8">


### PR DESCRIPTION
## Summary
- Added support for header images in markdown posts via front matter
- Header images display above the article content in a dedicated section
- Improved styling for inline markdown images to prevent them from overwhelming content

## Changes
1. **Added `headerImage` field** to PostMetadata interface in `src/lib/content.ts`
2. **Updated ResourcePost component** to display header images in a separate card above the article header
3. **Added CSS styles** for markdown images to ensure proper sizing and spacing
4. **Updated example post** to use the new header image field in front matter

## Test plan
- [x] Verified header image displays correctly on the step-up-to-the-plate post
- [x] Confirmed header image is properly sized and centered
- [x] Tested that posts without header images still render correctly
- [x] Verified inline markdown images are properly styled

🤖 Generated with [Claude Code](https://claude.ai/code)