### PR TITLE
Fix RLS security issue with adventure_sessions_public view

### DIFF
--- a/supabase/migrations/20250804000000_fix_adventure_sessions_view_security.sql
+++ b/supabase/migrations/20250804000000_fix_adventure_sessions_view_security.sql
@@ -1,0 +1,26 @@
+-- Fix adventure_sessions_public view to use SECURITY INVOKER
+-- This ensures the view respects the RLS policies of the querying user
+-- rather than bypassing them with the view owner's permissions
+
+-- Drop the existing view
+DROP VIEW IF EXISTS adventure_sessions_public;
+
+-- Recreate the view with SECURITY INVOKER
+-- This view provides public access to non-sensitive session fields
+CREATE VIEW adventure_sessions_public 
+WITH (security_invoker = true) AS
+SELECT 
+    id,
+    player_name,
+    is_generated_name,
+    current_scene_id,
+    created_at,
+    updated_at
+FROM adventure_sessions;
+
+-- Grant access to the view for anonymous users
+GRANT SELECT ON adventure_sessions_public TO anon;
+
+-- Add documentation
+COMMENT ON VIEW adventure_sessions_public IS 
+'Public view of adventure sessions that excludes sensitive fields like email and preferences. Uses SECURITY INVOKER to respect RLS policies of the querying user.';


### PR DESCRIPTION
## Summary
- Fixed Supabase security advisor warning about `adventure_sessions_public` view using SECURITY DEFINER
- Changed view to use SECURITY INVOKER to properly respect RLS policies

## Changes
- Created migration to drop and recreate the `adventure_sessions_public` view
- Added `WITH (security_invoker = true)` to ensure the view respects the querying user's RLS policies
- Migration has been successfully applied to the remote database

## Test plan
- [x] Migration applied successfully to remote database
- [x] View now properly respects RLS policies instead of bypassing them
- [x] Supabase security advisor issue resolved

🤖 Generated with [Claude Code](https://claude.ai/code)