### PR TITLE
Fix: Automatic scroll to top on route navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 
 import { Toaster as Sonner } from "@/components/ui/sonner";
@@ -18,6 +18,16 @@ import ResourcePost from "./pages/ResourcePost";
 import Resources from "./pages/Resources";
 
 const queryClient = new QueryClient();
+
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
 
 const App = () => {
   useEffect(() => {
@@ -37,6 +47,7 @@ const App = () => {
         <Toaster />
         <Sonner />
         <BrowserRouter>
+          <ScrollToTop />
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/about" element={<About />} />


### PR DESCRIPTION
## Summary
- Added ScrollToTop component that automatically scrolls to the top of the page when navigating between routes
- Fixes issue where clicking links would maintain scroll position from the previous page

## Test plan
- [x] Navigate between pages using navigation links
- [x] Verify page scrolls to top on each navigation
- [x] Test with links from different scroll positions

🤖 Generated with [Claude Code](https://claude.ai/code)