### PR TITLE
Fix: Allow numbers in name validation for testing flexibility

### DIFF
--- a/src/components/adventure/__tests__/AdventureGameForms.test.tsx
+++ b/src/components/adventure/__tests__/AdventureGameForms.test.tsx
@@ -319,8 +319,8 @@ describe('Adventure Game Forms', () => {
         // Test that form can handle error states
         render(<LaunchControlWaitlistForm onSuccess={mockOnSuccess} />)
         
-        // Test with invalid name (contains numbers)
-        await user.type(screen.getByPlaceholderText('Your name'), 'Jane123')
+        // Test with invalid name (contains special characters not allowed)
+        await user.type(screen.getByPlaceholderText('Your name'), 'Jane@123')
         await user.type(screen.getByPlaceholderText('your@email.com'), 'jane@example.com')
         
         const submitButton = screen.getByRole('button', { name: /Submit for Review/i })
@@ -477,8 +477,8 @@ describe('Adventure Game Forms', () => {
       it('prevents XSS in text fields', async () => {
         render(<LaunchControlWaitlistForm onSuccess={mockOnSuccess} />)
         
-        // Test with numbers in name which is invalid
-        await user.type(screen.getByPlaceholderText('Your name'), 'Name123')
+        // Test with special characters in name which is invalid
+        await user.type(screen.getByPlaceholderText('Your name'), 'Name$123')
         await user.type(screen.getByPlaceholderText('your@email.com'), 'test@example.com')
         
         const submitButton = screen.getByRole('button', { name: /Submit for Review/i })

--- a/src/components/adventure/__tests__/AdventureGameForms.test.tsx
+++ b/src/components/adventure/__tests__/AdventureGameForms.test.tsx
@@ -280,7 +280,7 @@ describe('Adventure Game Forms', () => {
         // Should show validation errors
         await waitFor(() => {
           // LaunchControl uses zod validation which shows specific error messages
-          expect(screen.getByText(/Name can only contain letters/i)).toBeInTheDocument()
+          expect(screen.getByText(/Name can only contain letters, numbers/i)).toBeInTheDocument()
         })
       })
 
@@ -328,7 +328,7 @@ describe('Adventure Game Forms', () => {
         
         // Should show validation error for invalid name
         await waitFor(() => {
-          expect(screen.getByText(/Name can only contain letters/i)).toBeInTheDocument()
+          expect(screen.getByText(/Name can only contain letters, numbers/i)).toBeInTheDocument()
         })
       })
     })
@@ -486,7 +486,7 @@ describe('Adventure Game Forms', () => {
         
         // Should show validation error for invalid name
         await waitFor(() => {
-          expect(screen.getByText(/Name can only contain letters/i)).toBeInTheDocument()
+          expect(screen.getByText(/Name can only contain letters, numbers/i)).toBeInTheDocument()
         })
       })
     })

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -12,7 +12,7 @@ const nameSchema = z
   .string()
   .min(2, 'Name must be at least 2 characters')
   .max(50, 'Name must be less than 50 characters')
-  .regex(/^[a-zA-Z\s'-]+$/, 'Name can only contain letters, spaces, hyphens, and apostrophes')
+  .regex(/^[a-zA-Z0-9\s'-]+$/, 'Name can only contain letters, numbers, spaces, hyphens, and apostrophes')
   .trim();
 
 const optionalNameSchema = nameSchema.optional().or(z.literal(''));


### PR DESCRIPTION
## Summary
- Fixed overly restrictive name validation that prevented testing with names containing numbers
- Updated validation regex to allow numbers in addition to letters, spaces, hyphens, and apostrophes
- Updated corresponding test expectations to match new validation message

## Technical Changes
- Modified `nameSchema` regex from `/^[a-zA-Z\s'-]+$/` to `/^[a-zA-Z0-9\s'-]+$/`
- Updated error message to include "numbers" in allowed character list
- Updated test assertions in `AdventureGameForms.test.tsx` to match new validation message

## Security & Validation
- Maintains security posture through character restrictions and HTML sanitization
- Preserves length limits (2-50 characters) and other validation rules
- Only adds numeric characters to allowed set, no special characters

## Testing
- All validation tests pass with updated expectations
- Enables testing with names like "Craig Sturgis2025-08-28-10-56"
- Build and lint checks pass successfully

## Test plan
- [x] Verify form accepts names with numbers (e.g., "John123", "Test2025")
- [x] Confirm security measures still prevent XSS attacks
- [x] Check that other validation rules (length limits) still work
- [x] Ensure tests pass with updated expectations

🤖 Generated with [Claude Code](https://claude.ai/code)