### PR TITLE
feat: improve case study resources layout for fewer than 3 items

### DIFF
--- a/app/transformation/TransformationClient.tsx
+++ b/app/transformation/TransformationClient.tsx
@@ -12,6 +12,8 @@ import {
   Play,
   Volume2,
   VolumeX,
+  Calendar,
+  FileText,
 } from "lucide-react";
 
 import { useEffect, useRef, useState } from "react";
@@ -19,11 +21,20 @@ import { useEffect, useRef, useState } from "react";
 import { Navigation } from "@/components/Navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { OptimizedImage } from "@/components/OptimizedImage";
 import { addSavvyCalTracking } from "@/lib/analytics";
 import { CostOfDelayCalculator } from "@/components/CostOfDelayCalculator";
 import { EmailOptIn } from "@/components/EmailOptIn";
+import { PostMetadata } from "@/lib/posts";
+import { formatPostDate } from "@/lib/dateUtils";
+import Link from "next/link";
 
-export function TransformationClient() {
+interface TransformationClientProps {
+  posts: PostMetadata[];
+}
+
+export function TransformationClient({ posts }: TransformationClientProps) {
   const heroLinkRef = useRef<HTMLAnchorElement>(null);
   const bottomLinkRef = useRef<HTMLAnchorElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -126,6 +137,13 @@ export function TransformationClient() {
     "50% Cost Reduction through efficiency gains",
     "Infinite Scaling Potential with elastic infrastructure",
   ];
+
+  // Filter posts for case studies with transformation tag
+  const caseStudyPosts = posts.filter(
+    (post) => 
+      post.tags?.includes('case-study') && 
+      post.tags?.includes('transformation')
+  );
 
   return (
     <>
@@ -472,6 +490,100 @@ export function TransformationClient() {
               />
             </div>
           </section>
+
+          {/* Transformation Case Studies Section */}
+          {caseStudyPosts.length > 0 && (
+            <section className="py-20 px-6">
+              <div className="max-w-6xl mx-auto">
+                <div className="text-center mb-16">
+                  <h2 className="text-4xl md:text-5xl font-bold text-white mb-6">
+                    Transformation Case Studies
+                  </h2>
+                  <p className="text-xl text-gray-300 max-w-3xl mx-auto">
+                    Real-world examples of AI-powered transformation in action.
+                  </p>
+                </div>
+
+                <div className={`grid gap-8 ${
+                  caseStudyPosts.length === 1 
+                    ? 'max-w-2xl mx-auto' 
+                    : caseStudyPosts.length === 2 
+                    ? 'md:grid-cols-2 max-w-4xl mx-auto' 
+                    : 'md:grid-cols-2 lg:grid-cols-3'
+                }`}>
+                  {caseStudyPosts.map((post) => (
+                    <Link key={post.slug} href={`/resources/${post.slug}`}>
+                      <Card className="bg-white/5 backdrop-blur-sm border-white/10 hover:border-white/20 transition-all duration-300 hover:scale-105 group cursor-pointer h-full overflow-hidden">
+                        {post.headerImage && (
+                          <div className="relative h-48 w-full">
+                            <OptimizedImage
+                              src={post.headerImage}
+                              alt={post.title}
+                              fill
+                              className="object-cover"
+                              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                            />
+                          </div>
+                        )}
+                        <CardContent className="p-6">
+                          <div className="flex items-center justify-between mb-4">
+                            <div className="p-2 bg-purple-500/20 rounded-lg">
+                              <FileText className="w-5 h-5 text-purple-400" />
+                            </div>
+                            <Badge className="bg-purple-500/20 text-purple-400">
+                              Case Study
+                            </Badge>
+                          </div>
+
+                          <h3 className="text-xl font-bold text-white mb-3 group-hover:text-purple-400 transition-colors">
+                            {post.title}
+                          </h3>
+
+                          <p className="text-gray-300 mb-4 leading-relaxed">
+                            {post.description}
+                          </p>
+
+                          <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
+                            <div className="flex items-center">
+                              <Calendar className="w-4 h-4 mr-1" />
+                              {formatPostDate(post.date)}
+                            </div>
+                            <span>{post.readTime}</span>
+                          </div>
+
+                          {post.tags && post.tags.length > 0 && (
+                            <div className="flex flex-wrap gap-2">
+                              {post.tags.filter(tag => ['transformation', 'case-study', 'augmented-engineering'].includes(tag)).slice(0, 3).map((tag) => (
+                                <Badge
+                                  key={tag}
+                                  variant="outline"
+                                  className="border-white/20 text-white/70 text-xs"
+                                >
+                                  {tag}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </CardContent>
+                      </Card>
+                    </Link>
+                  ))}
+                </div>
+
+                <div className="text-center mt-12">
+                  <Link href="/resources">
+                    <Button
+                      variant="outline"
+                      className="border-white/20 text-white hover:bg-white/10"
+                    >
+                      View All Resources
+                      <ArrowRight className="ml-2 w-4 h-4" />
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+            </section>
+          )}
 
           {/* Process Section */}
           <section className="py-20 px-6 bg-black/20">

--- a/app/transformation/page.tsx
+++ b/app/transformation/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { getAllPosts } from '@/lib/posts'
 import { TransformationClient } from './TransformationClient'
 
 export const metadata: Metadata = {
@@ -29,6 +30,7 @@ export const metadata: Metadata = {
   }
 }
 
-export default function TransformationPage() {
-  return <TransformationClient />
+export default async function TransformationPage() {
+  const posts = await getAllPosts()
+  return <TransformationClient posts={posts} />
 }


### PR DESCRIPTION
Add responsive grid layout that looks good on larger screens when there are fewer than 3 case studies:

- 1 item: Centers with max-w-2xl for optimal width  
- 2 items: Uses 2-column grid with max-w-4xl constraint
- 3+ items: Standard 3-column responsive grid

Also implements the case study resources section with proper filtering by 'case-study' and 'transformation' tags.

Closes #72

Generated with [Claude Code](https://claude.ai/code)