### PR TITLE
Optimize transformation page case studies layout and data filtering

### DIFF
--- a/app/transformation/TransformationClient.tsx
+++ b/app/transformation/TransformationClient.tsx
@@ -104,12 +104,8 @@ export function TransformationClient({ posts = [] }: TransformationClientProps) 
     }
   };
 
-  // Filter posts for case studies with transformation tag
-  const transformationCaseStudies = posts.filter(
-    (post) =>
-      post.tags.includes("case-study") &&
-      post.tags.includes("transformation")
-  );
+  // Posts are now already filtered at build time
+  const transformationCaseStudies = posts;
 
   const features = [
     {
@@ -577,7 +573,13 @@ export function TransformationClient({ posts = [] }: TransformationClientProps) 
                   </p>
                 </div>
 
-                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <div className={`grid gap-8 ${
+                  transformationCaseStudies.length === 1 
+                    ? 'grid-cols-1 max-w-md mx-auto' 
+                    : transformationCaseStudies.length === 2 
+                      ? 'grid-cols-1 md:grid-cols-2 max-w-4xl mx-auto' 
+                      : 'md:grid-cols-2 lg:grid-cols-3'
+                }`}>
                   {transformationCaseStudies.map((post) => (
                     <Link key={post.slug} href={`/resources/${post.slug}`}>
                       <Card className="bg-white/5 backdrop-blur-sm border-white/10 hover:border-white/20 transition-all duration-300 hover:scale-105 group cursor-pointer h-full overflow-hidden">

--- a/app/transformation/page.tsx
+++ b/app/transformation/page.tsx
@@ -32,5 +32,13 @@ export const metadata: Metadata = {
 
 export default async function TransformationPage() {
   const posts = await getAllPosts()
-  return <TransformationClient posts={posts} />
+  
+  // Filter posts for case studies with transformation tag at build time
+  const transformationCaseStudies = posts.filter(
+    (post) =>
+      post.tags.includes("case-study") &&
+      post.tags.includes("transformation")
+  )
+  
+  return <TransformationClient posts={transformationCaseStudies} />
 }


### PR DESCRIPTION
Implements the optimizations requested in #103:

**🚀 Performance Improvements**
- Move case study filtering from runtime to build time for better performance
- Reduce client bundle size by only passing filtered posts

**🎨 Layout Enhancements**
- Adaptive grid layout that centers content when fewer than 3 case studies
- Responsive design: 1 item (centered single column), 2 items (centered dual column), 3+ (original grid)

**🔧 Technical Changes**
- `app/transformation/page.tsx`: Added build-time filtering logic
- `app/transformation/TransformationClient.tsx`: Removed runtime filtering, added adaptive grid classes

Fixes #103

Generated with [Claude Code](https://claude.ai/code)