### PR TITLE
fix: Filter out browser extension errors from Sentry reporting

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -12,6 +12,21 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Filter out browser extension errors
+  beforeSend(event) {
+    // Filter out browser extension related errors
+    if (event.exception) {
+      const error = event.exception.values?.[0];
+      if (error?.value?.includes('runtime.sendMessage') ||
+          error?.value?.includes('Tab not found') ||
+          error?.value?.includes('chrome-extension://') ||
+          error?.value?.includes('moz-extension://')) {
+        return null; // Don't send this event
+      }
+    }
+    return event;
+  },
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -13,4 +13,19 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Filter out browser extension errors
+  beforeSend(event) {
+    // Filter out browser extension related errors
+    if (event.exception) {
+      const error = event.exception.values?.[0];
+      if (error?.value?.includes('runtime.sendMessage') ||
+          error?.value?.includes('Tab not found') ||
+          error?.value?.includes('chrome-extension://') ||
+          error?.value?.includes('moz-extension://')) {
+        return null; // Don't send this event
+      }
+    }
+    return event;
+  },
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -12,4 +12,19 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Filter out browser extension errors
+  beforeSend(event) {
+    // Filter out browser extension related errors
+    if (event.exception) {
+      const error = event.exception.values?.[0];
+      if (error?.value?.includes('runtime.sendMessage') ||
+          error?.value?.includes('Tab not found') ||
+          error?.value?.includes('chrome-extension://') ||
+          error?.value?.includes('moz-extension://')) {
+        return null; // Don't send this event
+      }
+    }
+    return event;
+  },
 });


### PR DESCRIPTION
Fixes issue #126

## Summary
- Add beforeSend filter to all Sentry configurations
- Filter out runtime.sendMessage(), Tab not found, and extension URL errors
- Prevents false positives from browser extensions interfering with the app

## Root Cause
Browser extensions running in users' browsers were generating false positive errors by trying to communicate with invalid tab contexts.

## Changes
- `sentry.edge.config.ts` - Added beforeSend filter for edge runtime
- `sentry.server.config.ts` - Added beforeSend filter for server runtime
- `instrumentation-client.ts` - Added beforeSend filter for client runtime

Generated with [Claude Code](https://claude.ai/code)