### PR TITLE
Fix: Resolve SECURITY DEFINER warning on adventure_choices_unified view

### DIFF
--- a/supabase/migrations/20250905000000_fix_adventure_choices_unified_security_definer.sql
+++ b/supabase/migrations/20250905000000_fix_adventure_choices_unified_security_definer.sql
@@ -1,0 +1,24 @@
+-- Fix SECURITY DEFINER issue with adventure_choices_unified view
+-- Recreate the view with explicit SECURITY INVOKER to resolve security linter warning
+
+DROP VIEW IF EXISTS adventure_choices_unified;
+
+-- Create the view with explicit SECURITY INVOKER (default behavior, but made explicit)
+CREATE VIEW adventure_choices_unified 
+WITH (security_invoker = true) AS 
+SELECT 
+  id,
+  session_id,
+  COALESCE(scene_id, 'scene_' || question_number::text) as scene_id,
+  COALESCE(choice_id, choice_value) as choice_id,
+  choice_text,
+  COALESCE(made_at, answered_at) as made_at,
+  -- Legacy columns for backward compatibility
+  question_number,
+  question_text,
+  choice_value,
+  answered_at
+FROM adventure_choices;
+
+-- Restore grants
+GRANT SELECT ON adventure_choices_unified TO anon, authenticated;


### PR DESCRIPTION
## Summary
Fixes security linter warning VIB-152 by recreating the `adventure_choices_unified` view with explicit `security_invoker=true` setting.

## Changes
- Created migration `20250905000000_fix_adventure_choices_unified_security_definer.sql`
- Drops and recreates the view with explicit `WITH (security_invoker = true)` clause
- Maintains full backward compatibility with existing column structure
- Restores appropriate grants for `anon` and `authenticated` roles

## Test plan
- [x] Migration applied successfully to database
- [x] Lint and build checks pass without errors
- [x] Code review confirms security best practices
- [x] Backward compatibility verified with COALESCE logic for legacy columns

🤖 Generated with [Claude Code](https://claude.ai/code)