### PR TITLE
feat: implement StandardLayout component for shared footer positioning

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Navigation } from "@/components/Navigation";
+import { StandardLayout } from "@/components/StandardLayout";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -19,10 +19,8 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
   return (
-    <>
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
-        <Navigation />
-        <div className="pt-32 pb-20 px-6">
+    <StandardLayout>
+      <div className="pt-32 pb-20 px-6">
           <div className="max-w-4xl mx-auto">
             {/* Header Section */}
             <div className="text-center mb-16">
@@ -241,7 +239,6 @@ export default function AboutPage() {
             </Card>
           </div>
         </div>
-      </div>
-    </>
+    </StandardLayout>
   );
 }

--- a/app/ignition/IgnitionClient.tsx
+++ b/app/ignition/IgnitionClient.tsx
@@ -14,7 +14,7 @@ import { useState } from "react";
 
 import { EmailOptIn } from "@/components/EmailOptIn";
 import { IgnitionQualificationForm } from "@/components/IgnitionQualificationForm";
-import { Navigation } from "@/components/Navigation";
+import { StandardLayout } from "@/components/StandardLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -64,9 +64,7 @@ export function IgnitionClient() {
 
   return (
     <>
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
-        <Navigation />
-
+      <StandardLayout>
         <div className="pt-20">
         {/* Hero Section */}
         <section className="py-20 px-6">
@@ -249,7 +247,7 @@ export function IgnitionClient() {
           />
         </DialogContent>
       </Dialog>
-      </div>
+      </StandardLayout>
     </>
   );
 }

--- a/app/launch-control/LaunchControlClient.tsx
+++ b/app/launch-control/LaunchControlClient.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 
 import { EmailOptIn } from "@/components/EmailOptIn";
 import { LaunchControlQualificationForm } from "@/components/LaunchControlQualificationForm";
-import { Navigation } from "@/components/Navigation";
+import { StandardLayout } from "@/components/StandardLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -71,9 +71,7 @@ export function LaunchControlClient() {
 
   return (
     <>
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
-        <Navigation />
-
+      <StandardLayout>
         <div className="pt-20">
         {/* Hero Section */}
         <section className="py-20 px-6">
@@ -282,7 +280,7 @@ export function LaunchControlClient() {
           />
         </DialogContent>
       </Dialog>
-      </div>
+      </StandardLayout>
     </>
   );
 }

--- a/app/resources/ResourcesClient.tsx
+++ b/app/resources/ResourcesClient.tsx
@@ -4,7 +4,7 @@ import { Calendar, FileText, Code } from "lucide-react";
 import Link from "next/link";
 
 import { EmailOptIn } from "@/components/EmailOptIn";
-import { Navigation } from "@/components/Navigation";
+import { StandardLayout } from "@/components/StandardLayout";
 import { OptimizedImage } from "@/components/OptimizedImage";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -45,10 +45,8 @@ export function ResourcesClient({ posts }: ResourcesClientProps) {
   const regularPosts = posts.filter((post) => !post.featured);
 
   return (
-    <>
-      <Navigation />
+    <StandardLayout className="bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900">
       <div className="pt-20">
-        <div className="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900">
           <div className="px-6">
             <div className="max-w-6xl mx-auto">
               {/* Header */}
@@ -231,8 +229,7 @@ export function ResourcesClient({ posts }: ResourcesClientProps) {
               )}
             </div>
           </div>
-        </div>
       </div>
-    </>
+    </StandardLayout>
   );
 }

--- a/app/transformation/TransformationClient.tsx
+++ b/app/transformation/TransformationClient.tsx
@@ -19,7 +19,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 
-import { Navigation } from "@/components/Navigation";
+import { StandardLayout } from "@/components/StandardLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -143,9 +143,7 @@ export function TransformationClient({ posts = [] }: TransformationClientProps) 
 
   return (
     <>
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
-        <Navigation />
-
+      <StandardLayout>
         <div className="pt-20">
           {/* Hero Section */}
           <section className="py-20 px-6">
@@ -734,7 +732,7 @@ export function TransformationClient({ posts = [] }: TransformationClientProps) 
             </div>
           </section>
         </div>
-      </div>
+      </StandardLayout>
     </>
   );
 }

--- a/src/components/StandardLayout.tsx
+++ b/src/components/StandardLayout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+
+interface StandardLayoutProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Shared layout component for standard pages (non-adventure pages).
+ * Provides consistent Navigation and Footer with proper flex layout.
+ */
+export function StandardLayout({ children, className = "" }: StandardLayoutProps) {
+  return (
+    <div className={`min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex flex-col ${className}`}>
+      <Navigation />
+      <div className="flex-grow">
+        {children}
+      </div>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #131

This PR creates a shared StandardLayout component that eliminates repetitive Footer imports across standard pages.

## Changes
- Create StandardLayout component at `src/components/StandardLayout.tsx`
- Update About, Ignition, Launch Control, Transformation, and Resources pages
- Provides consistent Navigation + Footer structure with proper flex layout
- Adventure pages remain unchanged as requested

## Benefits
- No more repetitive imports for Navigation/Footer
- Consistent layout structure across standard pages
- Footer automatically positioned at bottom
- Easier maintenance - layout changes in one place

Generated with [Claude Code](https://claude.ai/code)