### PR TITLE
feat: add Vercel Speed Insights to app layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://vibecto.ai"),
@@ -54,6 +55,7 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body>
         <GoogleAnalytics />
+        <SpeedInsights />
         <Providers>
           <div id="root">{children}</div>
         </Providers>

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@slack/web-api": "^7.10.0",
         "@supabase/supabase-js": "^2.50.3",
         "@tanstack/react-query": "^5.56.2",
+        "@vercel/speed-insights": "^1.1.0",
         "buffer": "^6.0.3",
         "caniuse-lite": "^1.0.30001726",
         "class-variance-authority": "^0.7.1",
@@ -7644,6 +7645,41 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@slack/web-api": "^7.10.0",
     "@supabase/supabase-js": "^2.50.3",
     "@tanstack/react-query": "^5.56.2",
+    "@vercel/speed-insights": "^1.1.0",
     "buffer": "^6.0.3",
     "caniuse-lite": "^1.0.30001726",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Added Vercel Speed Insights integration to track performance metrics

- Added @vercel/speed-insights dependency to package.json
- Imported SpeedInsights component in app/layout.tsx
- Added SpeedInsights component alongside GoogleAnalytics

Fixes #140

Generated with [Claude Code](https://claude.ai/code)