### PR TITLE
feat: add Vercel web analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
+import { Analytics } from '@vercel/analytics/react';
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://vibecto.ai"),
@@ -54,6 +55,7 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body>
         <GoogleAnalytics />
+        <Analytics />
         <Providers>
           <div id="root">{children}</div>
         </Providers>

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@slack/web-api": "^7.10.0",
     "@supabase/supabase-js": "^2.50.3",
     "@tanstack/react-query": "^5.56.2",
+    "@vercel/analytics": "^1.4.2",
     "buffer": "^6.0.3",
     "caniuse-lite": "^1.0.30001726",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
This PR implements Vercel web analytics by:

- Installing @vercel/analytics package
- Adding Analytics component to app layout alongside GoogleAnalytics
- Analytics will automatically track page views and user interactions

Closes #139

Generated with [Claude Code](https://claude.ai/code)