### PR TITLE
fix: breakout game leaderboard Slack notifications

### DIFF
--- a/app/api/breakout-leaderboard/route.ts
+++ b/app/api/breakout-leaderboard/route.ts
@@ -77,18 +77,28 @@ export async function POST(request: NextRequest) {
       ? `https://${process.env.VERCEL_URL}`
       : process.env.NEXTAUTH_URL || 'http://localhost:3000';
     
+    const slackPayload = {
+      formType: 'breakout_score',
+      additionalData: {
+        initials: initials.toUpperCase(),
+        score: score,
+        difficulty: difficulty,
+        linkedin_username: cleanUsername,
+      },
+    };
+    
+    console.log("Sending Slack notification to:", `${baseUrl}/api/slack-notify`);
+    console.log("Payload:", JSON.stringify(slackPayload, null, 2));
+    
     fetch(`${baseUrl}/api/slack-notify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        formType: 'breakout_score',
-        additionalData: {
-          initials: initials.toUpperCase(),
-          score: score,
-          difficulty: difficulty,
-          linkedin_username: cleanUsername,
-        },
-      }),
+      body: JSON.stringify(slackPayload),
+    }).then(response => {
+      console.log("Slack notification response status:", response.status);
+      return response.json();
+    }).then(result => {
+      console.log("Slack notification result:", result);
     }).catch(slackError => {
       console.error("Error sending Slack notification:", slackError);
       // Fire and forget - don't block the main response

--- a/app/api/breakout-leaderboard/route.ts
+++ b/app/api/breakout-leaderboard/route.ts
@@ -73,9 +73,23 @@ export async function POST(request: NextRequest) {
     }
 
     // Send Slack notification using centralized system (fire and forget)
-    const baseUrl = process.env.VERCEL_URL 
-      ? `https://${process.env.VERCEL_URL}`
-      : process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    // Use the same URL construction logic as the working email subscription route
+    let siteUrl = "http://localhost:3000"; // Default fallback
+    
+    if (process.env.NODE_ENV === "production") {
+      siteUrl = "https://vibecto.ai";
+    } else if (process.env.NODE_ENV === "development") {
+      siteUrl = "http://localhost:8080";
+    } else if (process.env.DEPLOY_PRIME_URL) {
+      // Netlify deploy preview
+      siteUrl = process.env.DEPLOY_PRIME_URL;
+    } else if (process.env.DEPLOY_URL) {
+      // Netlify branch deploy
+      siteUrl = process.env.DEPLOY_URL;
+    } else if (process.env.NEXT_PUBLIC_SITE_URL) {
+      // Fallback to public site URL if set
+      siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+    }
     
     const slackPayload = {
       formType: 'breakout_score',
@@ -87,10 +101,10 @@ export async function POST(request: NextRequest) {
       },
     };
     
-    console.log("Sending Slack notification to:", `${baseUrl}/api/slack-notify`);
+    console.log("Sending Slack notification to:", `${siteUrl}/api/slack-notify`);
     console.log("Payload:", JSON.stringify(slackPayload, null, 2));
     
-    fetch(`${baseUrl}/api/slack-notify`, {
+    fetch(`${siteUrl}/api/slack-notify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(slackPayload),

--- a/app/api/slack-notify/route.ts
+++ b/app/api/slack-notify/route.ts
@@ -181,8 +181,8 @@ function formatFormSubmissionMessage(data: any) {
     }
   ];
 
-  // Add additional data if present
-  if (additionalData && Object.keys(additionalData).length > 0) {
+  // Add additional data if present (but not for breakout_score as it's already handled above)
+  if (additionalData && Object.keys(additionalData).length > 0 && formType !== 'breakout_score') {
     const additionalFields = Object.entries(additionalData).map(([key, value]) => ({
       type: 'mrkdwn',
       text: `*${key}:*\n${value}`


### PR DESCRIPTION
Updates breakout leaderboard to use centralized Slack notification system instead of direct webhooks.

Changes:
- Add 'breakout_score' support to /api/slack-notify with custom formatting
- Replace SLACK_WEBHOOK_URL dependency with existing SLACK_BOT_TOKEN system
- Ensure consistent notification handling across all form submissions

Fixes #163

Generated with [Claude Code](https://claude.ai/code)